### PR TITLE
ci: build an arm64 (Raspberry Pi) .deb on a native runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -264,7 +264,15 @@ jobs:
 
   build-deb:
     needs: test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ARCH: amd64
+            OS: ubuntu-latest
+          - ARCH: arm64
+            OS: ubuntu-24.04-arm
+    runs-on: ${{ matrix.OS }}
     steps:
       - uses: actions/checkout@v4
 
@@ -277,8 +285,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ./target
-          key: deb-cargo-registry-${{ hashFiles('Cargo.lock') }}
-      
+          key: deb-cargo-registry-${{ matrix.ARCH }}-${{ hashFiles('Cargo.lock') }}
+
       - name: Install cargo-deb
         run: cargo install cargo-deb
 
@@ -291,7 +299,7 @@ jobs:
       - name: Archive Debian package
         uses: actions/upload-artifact@v4
         with:
-          name: result-deb
+          name: result-deb-${{ matrix.ARCH }}
           path: target/debian/*.deb
 
   deploy:


### PR DESCRIPTION
Adds an arm64 Debian package to the release artifacts so Raspberry Pi (and other aarch64) users can install from a `.deb` instead of building from source.

The existing `build-deb` job becomes a two-entry matrix (amd64 + arm64). The arm64 build runs on GitHub's native `ubuntu-24.04-arm` runner, so it's a plain `cargo build` / `cargo deb` with no cross-compilation, no QEMU, and no dependencies beyond what the job already installs.

`deploy` is left untouched — it already globs `*.deb`, so tagged releases pick up the new package automatically.

### Scope
- One file changed (`+12 / -4`); only the `build-deb` job is modified.
- Artifacts are renamed to `result-deb-amd64` / `result-deb-arm64` (unique names are required per matrix leg). The amd64 package is otherwise unchanged.

### Testing
Ran on my fork: the workflow is green and produces `rusty-pipes_<version>-1_arm64.deb`. Inspected it on a Raspberry Pi 5 — `dpkg --info` reports `Architecture: arm64`, with the binary under `/usr/bin` and the desktop/icon files in `/usr/share`.

One note: the arm64 leg currently builds on every push, mirroring the existing amd64 deb job. Glad to restrict it to tags if you'd rather keep arm64 runner usage down.
